### PR TITLE
adding failed queue to send task that failed after retry

### DIFF
--- a/config/amqp.go
+++ b/config/amqp.go
@@ -17,6 +17,7 @@ type AMQPConfig struct {
 	PrefetchCount      int              `env:"PREFETCH_COUNT" validate:"required"`
 	AutoDelete         bool             `env:"AUTO_DELETE"`
 	DelayedQueue       string           `env:"DELAYED_QUEUE" envDefault:"paota_task_delayed_queue"`
+	FailedQueue        string           `env:"FAILED_QUEUE" envDefault:"paota_task_failed_queue"`
 	ConnectionPoolSize int              `env:"CONNECTION_POOL_SIZE" envDefault:"5"`
 	HeartBeatInterval  int              `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/surendratiwari3/paota
 
-go 1.21.5
+go 1.23.4
 
 require (
 	github.com/caarlos0/env/v10 v10.0.0


### PR DESCRIPTION
<!-- Paota Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
- [x] Commits are split per component (broker, config, store, worker, workerpool, ...)
- [x] Each component has a single commit (if not, squash them into one commit)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Previously, when a task in Paota failed after exhausting all retry attempts, it was discarded silently. This could lead to data loss and make it difficult to trace or debug failed tasks.
✅ Solution
This PR introduces a Failure Queue mechanism in Paota.

Tasks that reach their maximum retry limit and still fail are now pushed into a dedicated failure_queue.

This ensures visibility into permanently failed tasks and allows for further processing, alerting, or manual intervention.