### PR TITLE
adding failed queue on max retry reached

### DIFF
--- a/config/amqp.go
+++ b/config/amqp.go
@@ -17,6 +17,7 @@ type AMQPConfig struct {
 	PrefetchCount      int              `env:"PREFETCH_COUNT" validate:"required"`
 	AutoDelete         bool             `env:"AUTO_DELETE"`
 	DelayedQueue       string           `env:"DELAYED_QUEUE" envDefault:"paota_task_delayed_queue"`
+	FailedQueue        string           `env:"FAILED_QUEUE" envDefault:"paota_task_failed_queue"`
 	ConnectionPoolSize int              `env:"CONNECTION_POOL_SIZE" envDefault:"5"`
 	HeartBeatInterval  int              `env:"HEARTBEAT_INTERVAL" envDefault:"10"`
 }

--- a/internal/broker/amqp/broker.go
+++ b/internal/broker/amqp/broker.go
@@ -187,7 +187,6 @@ func (b *AMQPBroker) setupExchangeQueueBinding() error {
 	if err != nil {
 		return err
 	}
-
 	// Bind the queue to the exchange
 	err = b.amqpProvider.QueueExchangeBind(channel, b.getTaskQueue(), b.config.AMQP.BindingKey, b.config.AMQP.Exchange)
 	if err != nil {
@@ -195,6 +194,17 @@ func (b *AMQPBroker) setupExchangeQueueBinding() error {
 	}
 
 	err = b.amqpProvider.QueueExchangeBind(channel, b.getDelayedQueue(), b.getDelayedQueue(), b.getDelayedQueueDLX())
+	if err != nil {
+		return err
+	}
+
+	// Bind Queue and Bind
+	err = b.amqpProvider.DeclareQueue(channel, b.getFailedQueue(), declareQueueArgs)
+	if err != nil {
+		return err
+	}
+
+	err = b.amqpProvider.QueueExchangeBind(channel, b.getFailedQueue(), b.getFailedQueue(), b.config.AMQP.Exchange)
 	if err != nil {
 		return err
 	}
@@ -278,6 +288,10 @@ func (b *AMQPBroker) StartConsumer(ctx context.Context, workerGroup workergroup.
 
 func (b *AMQPBroker) getDelayedQueue() string {
 	return b.config.AMQP.DelayedQueue
+}
+
+func (b *AMQPBroker) getFailedQueue() string {
+	return b.config.AMQP.FailedQueue
 }
 
 func (b *AMQPBroker) getQueuePrefetchCount() int {

--- a/internal/task/memory/task.go
+++ b/internal/task/memory/task.go
@@ -143,6 +143,7 @@ func (r *DefaultTaskRegistrar) retryTask(signature *schema.Signature) error {
 	} else {
 		retryInterval := r.getRetryInterval(signature.RetriesDone + 1)
 		if retryInterval > 0 {
+			signature.RetriesDone = signature.RetriesDone + 1
 			signature.RoutingKey = r.configProvider.GetConfig().AMQP.DelayedQueue
 		}
 		eta := time.Now().UTC().Add(retryInterval)

--- a/internal/task/memory/task.go
+++ b/internal/task/memory/task.go
@@ -135,19 +135,19 @@ func (r *DefaultTaskRegistrar) amqpMsgProcessor(job interface{}) error {
 }
 
 func (r *DefaultTaskRegistrar) retryTask(signature *schema.Signature) error {
+
 	if signature.RetryCount < 1 {
-		return nil
+		signature.RoutingKey = r.configProvider.GetConfig().AMQP.FailedQueue
+	} else if signature.RetriesDone > (signature.RetryCount - 1) {
+		signature.RoutingKey = r.configProvider.GetConfig().AMQP.FailedQueue
+	} else {
+		retryInterval := r.getRetryInterval(signature.RetriesDone + 1)
+		if retryInterval > 0 {
+			signature.RoutingKey = r.configProvider.GetConfig().AMQP.DelayedQueue
+		}
+		eta := time.Now().UTC().Add(retryInterval)
+		signature.ETA = &eta
 	}
-	signature.RetriesDone = signature.RetriesDone + 1
-	if signature.RetriesDone > signature.RetryCount {
-		return nil
-	}
-	retryInterval := r.getRetryInterval(signature.RetriesDone)
-	if retryInterval > 0 {
-		signature.RoutingKey = r.configProvider.GetConfig().AMQP.DelayedQueue
-	}
-	eta := time.Now().UTC().Add(retryInterval)
-	signature.ETA = &eta
 	return r.SendTask(signature)
 }
 


### PR DESCRIPTION
<!-- Paota Pull Request Template -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
- [x] Commits are split per component (broker, config, store, worker, workerpool, ...)
- [x] Each component has a single commit (if not, squash them into one commit)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
Previously, when a task in Paota failed after exhausting all retry attempts, it was discarded silently. This could lead to data loss and make it difficult to trace or debug failed tasks.

✅ Solution
This PR introduces a Failure Queue mechanism in Paota.

Tasks that reach their maximum retry limit and still fail are now pushed into a dedicated failure_queue (env AMQP_FAILED_QUEUE).

This ensures visibility into permanently failed tasks and allows for further processing, alerting, or manual intervention